### PR TITLE
Temporary fix for photo library asset urls being invalidated on iOS 13

### DIFF
--- a/src/ios/CDVCamera.h
+++ b/src/ios/CDVCamera.h
@@ -86,6 +86,7 @@ typedef NSUInteger CDVMediaType;
 
 @property (strong) CDVCameraPicker* pickerController;
 @property (strong) NSMutableDictionary *metadata;
+@property (strong) NSDictionary *latestMediaInfo;
 @property (strong, nonatomic) CLLocationManager *locationManager;
 @property (strong) NSData* data;
 

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -679,6 +679,8 @@ static NSString* toBase64(NSData* data) {
     __weak CDVCameraPicker* cameraPicker = (CDVCameraPicker*)picker;
     __weak CDVCamera* weakSelf = self;
     
+    self.latestMediaInfo = info;
+    
     dispatch_block_t invoke = ^(void) {
         __block CDVPluginResult* result = nil;
         


### PR DESCRIPTION
It seems that the path is actually correct, but that the url simply gets invalidated too soon, causing the file manager to not be able to find the file. The workaround is to keep a reference to the info object passed to the imagePickerController:didFinishPickingMediaWithInfo: method of the UIImagePickerControllerDelegate, and thus preventing the url from being invalidated.